### PR TITLE
Fix CSF bugs and add new options

### DIFF
--- a/SCheatmap.m
+++ b/SCheatmap.m
@@ -13,7 +13,7 @@ function [heatmap,freqmap,voxelDir]=SCheatmap(input_folder,write_out,bySlice,use
 % write_out----------->  1 or 0: 1 will write out files to current folder                        
 % bySlice ------------>  1 or 0: 1 will sort the heatmap by slice, 0 will sort by tissue type
 % useLevels ---------->  1 or 0: 1 will indicate vertebral levels on plot, 0 will not. 
-%                        WARNING: only use this if CSF is not included in masks
+%                        WARNING: Only use this if not including CSF!
 % TR ----------------->  TR in seconds
 % prefix ------------->  regressor/trace file prefix  -  e.g. 'sub-03'
 % trace_loc ---------->  full path to folder with physiological, task or other traces
@@ -79,6 +79,11 @@ end
 close all
 addpath(input_folder)
 addpath(trace_loc)
+% Check whether plotting CSF & using useLevels
+maskDescrip=fileread([input_folder '/maskDescriptions.txt']);
+if contains(maskDescrip,'CEREBROSPINAL FLUID') && useLevels==1
+    error('When including CSF in heatmap, useLevels cannot = 1.')
+end
 fprintf('\nBeginning... \n \n')
 %% Load data
 if options.PlotSmoothData==0

--- a/SCheatmap.m
+++ b/SCheatmap.m
@@ -47,11 +47,17 @@ function [heatmap,freqmap,voxelDir]=SCheatmap(input_folder,write_out,bySlice,use
 % voxelDir ----------->  directory of voxels that corresponds to heat map
 %                        
 %
-% NOTE: This script assumes a certain format for the prefix, followed by
+% NOTE 1: This script assumes a certain format for the prefix, followed by
 % the trace name, as follows: 'prefix_Trace.txt'
 %   E.g., Normal trace: 'sub-03_ses-BH_HR.txt'
 %         Convolved trace: 'sub-03_ses-BH_HR_CRFconv.txt'
 %         (similarly, _CO2_HRFconv.txt, _RVT_RRFconv.txt, _O2_HRFconv.txt)
+% 
+% NOTE 2: If you used a mask with -m in x.heatmapPrep, you should use:
+% useLevels=0, bySlice=1
+% 
+% NOTE 3: If you don't want to plot traces, use [] for the trace_loc
+% argument and use "plots", 1 to plot the basic plot.
 % 
 % 
 % Kimberly Hemmerling 2020
@@ -76,7 +82,6 @@ arguments
     options.stim (1,1) string = "-"
     options.slices (1,2) double {mustBeNumeric,mustBeInteger} = [-1 -1]
 end
-close all
 addpath(input_folder)
 addpath(trace_loc)
 % Check whether plotting CSF & using useLevels
@@ -345,6 +350,7 @@ elseif (options.plots==1) && (bySlice==1)
         set(gca,'XTickLabel',[],'xtick',[],'YTickLabel',[],'ytick',[])
         freqmap=0;
     end
+    freqmap=0;
     fprintf('\nPlotted basic plot... done!\n')
     return
 end
@@ -1071,7 +1077,7 @@ if all(options.moco ~= "-") && (options.plots==2)
 %     saveas(gcf,strcat(input_folder,'/',prefix,'_heatmap_motion_blur',options.PlotSmoothData,'.jpg'))
 end
 %% DVARS plot
-if (options.plots==2)
+if (options.plots==2) && isfile('dvars.txt')
     dvars=load('dvars.txt');
     dvars(1)=NaN;
     figure('Name','DVARS', 'Renderer', 'painters','Position', [50 1000 630 500])

--- a/x.heatmapPrep
+++ b/x.heatmapPrep
@@ -171,9 +171,9 @@ wm=${outputdir}/full_wm_mask.nii.gz
 # Option is prompted in command window for user input. More detailed comments are
 # provided in the WM section below.
 ###############################################################################
-o=0 #output
-i=0 #input
-m=0 #mask
+o=00 #output
+i=00 #input
+m=00 #mask
 if [[ ${include_CSF} -eq 2 ]]; then
     echo -n "Creating tissue type masks. GM/WM masks will be created. Do you want to include CSF? \e[42mEnter y or n:\e[0m "
     read YN
@@ -213,6 +213,9 @@ if [[ ${include_CSF} -eq 1 ]]; then
   while (( ${mask_avg} > 0 ))
   do
     o=$(( o+1 ))
+    if [[ ${o} -le 9 ]]; then
+      o="0"${o}
+    fi
     sct_maths -i ${outputdir}/erosion${i}.nii.gz -o ${outputdir}/erosion${o}.nii.gz -erode 1 -shape disk -dim 2
     sct_maths -i ${outputdir}/erosion${i}.nii.gz -o ${outputdir}/mask_TEMP.nii.gz -sub ${outputdir}/erosion${o}.nii.gz
     sct_maths -i ${outputdir}/mask_TEMP.nii.gz -o ${outputdir}/sub_cord_TEMP.nii.gz -sub ${cord}
@@ -221,6 +224,9 @@ if [[ ${include_CSF} -eq 1 ]]; then
     mask_avg=$( tail -1 ${outputdir}/mask_averages.txt )
     rm ${outputdir}/sub_cord_TEMP.nii.gz ${outputdir}/mask_TEMP.nii.gz
     i=$(( i+1 ))
+    if [[ ${i} -le 9 ]]; then
+      i="0"${i}
+    fi
     echo "CSF mask ${i} with average: " ${mask_avg}
     echo "mask${i}.nii.gz" >> ${outputdir}/maskDescriptions.txt
   done
@@ -242,7 +248,6 @@ if [[ ${include_CSF} -eq 1 ]]; then
 elif [[ include_CSF -eq 0 ]]; then
   echo "\n OK, no CSF. \n"
 fi
-# exit 1 #DELETE!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ###############################################################################
 # WM EROSION AND MASK CREATION:
 ###############################################################################
@@ -270,6 +275,9 @@ echo "mask${o}.nii.gz" >> ${outputdir}/maskDescriptions.txt
 while (( ${mask_avg} > 0 ))
 do
   o=$(( o+1 ))
+  if [[ ${o} -le 9 ]]; then
+    o="0"${o}
+  fi
   sct_maths -i ${outputdir}/erosion${i}.nii.gz -o ${outputdir}/erosion${o}.nii.gz -erode 1 -shape disk -dim 2
   sct_maths -i ${outputdir}/erosion${i}.nii.gz -o ${outputdir}/mask_TEMP.nii.gz -sub ${outputdir}/erosion${o}.nii.gz
   sct_maths -i ${outputdir}/mask_TEMP.nii.gz -o ${outputdir}/sub_gm_TEMP.nii.gz -sub ${gm}
@@ -278,6 +286,9 @@ do
   mask_avg=$( tail -1 ${outputdir}/mask_averages.txt )
   rm ${outputdir}/sub_gm_TEMP.nii.gz ${outputdir}/mask_TEMP.nii.gz
   i=$(( i+1 ))
+  if [[ ${i} -le 9 ]]; then
+    i="0"${i}
+  fi
   echo "WM mask ${i} with average: " ${mask_avg}
   echo "mask${i}.nii.gz" >> ${outputdir}/maskDescriptions.txt
 done
@@ -288,18 +299,24 @@ cp ${outputdir}/mask${i}.nii.gz ${outputdir}/checkIfEmpty_wm.nii.gz
 sed "s/mask${i}.nii.gz/------------/" ${outputdir}/maskDescriptions.txt > ${outputdir}/tempTemp.txt
 mv ${outputdir}/tempTemp.txt ${outputdir}/maskDescriptions.txt
 # Calculate timeseries for each mask:
-m=0
+m=00
 for mask in ${outputdir}/mask*.nii.gz
 do
 	echo "Processing mask $m"
   fslmeants -i ${func} -m ${mask} --showall > ${outputdir}/mask${m}ts.txt
   m=$(( m+1 ))
+  if [[ ${m} -le 9 ]]; then
+    m="0"${m}
+  fi
 done
 ###############################################################################
 # Gray matter:
 ###############################################################################
 # No erosion needed for GM because it is quite small already
 m=$(( m-1 ))
+if [[ ${m} -le 9 ]]; then
+  m="0"${m}
+fi
 # Save gray matter mask as last mask #
 cp ${gm} ${outputdir}/mask${m}.nii.gz
 echo "GM mask is mask${m}.nii.gz"
@@ -309,14 +326,23 @@ echo "GRAY MATTER" >> ${outputdir}/maskDescriptions.txt
 echo "mask${m}.nii.gz" >> ${outputdir}/maskDescriptions.txt
 ###############################################################################
 # Create mask visualization file allMaskVisualization.nii.gz
-v=0
-cp ${outputdir}/mask0.nii.gz ${outputdir}/allMaskVisualization.nii.gz
+v=00
+cp ${outputdir}/mask00.nii.gz ${outputdir}/allMaskVisualization.nii.gz
 for mask in ${outputdir}/mask*.nii.gz
 do
-  if (( $v == 0 )); then
+  if (( $v == 00 )); then
+    # Skip mask0 since it was already included as the base
     v=$(( v+1 ))
+    if [[ ${v} -le 9 ]]; then
+      v="0"${v}
+    fi
   else
     v=$(( v+1 ))
+    if [[ ${v} -le 9 ]]; then
+      v="0"${v}
+    fi
+    echo "${v}"
+    echo "\n ${mask}"
     fslmaths ${mask} -mul $v -add ${outputdir}/allMaskVisualization.nii.gz ${outputdir}/temp.nii.gz
     cp ${outputdir}/temp.nii.gz ${outputdir}/allMaskVisualization.nii.gz
   fi
@@ -382,12 +408,15 @@ if [[ ${smooth} -eq 1 ]]; then
     echo "Isotropic smoothing complete."
   fi
   # Calculate blurred timeseries for each mask (use for restricted or undrestricted methods)
-  m=0
+  m=00
   for mask in ${outputdir}/mask*.nii.gz
   do
   	echo "Processing mask $m in func_blur_cord.nii.gz"
     fslmeants -i ${outputdir}/func_blur_cord.nii.gz -m ${mask} --showall > ${outputdir}/blur_mask${m}ts.txt
     m=$(( m+1 ))
+    if [[ ${m} -le 9 ]]; then
+      m="0"${m}
+    fi
   done
 fi
 

--- a/x.heatmapPrep
+++ b/x.heatmapPrep
@@ -135,7 +135,7 @@ cd ${data_path}
 # Calculate functional mean image for visualizations later
 fslmaths ${func} -Tmean func_mean.nii.gz
 # The data_path should be the "label" folder containing these PAM50 files
-input=template/PAM50_cord.nii.gz # cord mask
+cord=template/PAM50_cord.nii.gz # cord mask
 levels=template/PAM50_levels.nii.gz # vertebral levels (NOT CORD)
 # Do checks then initialize mask descriptions log file
 if [[ -f "${outputdir}/maskDescriptions.txt" ]]; then
@@ -202,7 +202,7 @@ if [[ ${include_CSF} -eq 1 ]]; then
   # In sct 4.2.2 sct_maths used : -erode 3,3,1. Updated to sct v. 5.2.0 : -erode 1 -shape disk -dim 2
   sct_maths -i ${csfCord} -o ${outputdir}/erosion${o}.nii.gz -erode 1 -shape disk -dim 2
   sct_maths -i ${csfCord} -o ${outputdir}/mask_TEMP.nii.gz -sub ${outputdir}/erosion${o}.nii.gz
-  sct_maths -i ${outputdir}/mask_TEMP.nii.gz -o ${outputdir}/sub_cord_TEMP.nii.gz -sub ${input}
+  sct_maths -i ${outputdir}/mask_TEMP.nii.gz -o ${outputdir}/sub_cord_TEMP.nii.gz -sub ${cord}
   fslmaths ${outputdir}/sub_cord_TEMP.nii.gz -thr 0 -bin ${outputdir}/mask${o}.nii.gz
   fslstats ${outputdir}/mask${o}.nii.gz -m >> ${outputdir}/mask_averages.txt
   mask_avg=$( tail -1 ${outputdir}/mask_averages.txt )
@@ -215,7 +215,7 @@ if [[ ${include_CSF} -eq 1 ]]; then
     o=$(( o+1 ))
     sct_maths -i ${outputdir}/erosion${i}.nii.gz -o ${outputdir}/erosion${o}.nii.gz -erode 1 -shape disk -dim 2
     sct_maths -i ${outputdir}/erosion${i}.nii.gz -o ${outputdir}/mask_TEMP.nii.gz -sub ${outputdir}/erosion${o}.nii.gz
-    sct_maths -i ${outputdir}/mask_TEMP.nii.gz -o ${outputdir}/sub_cord_TEMP.nii.gz -sub ${input}
+    sct_maths -i ${outputdir}/mask_TEMP.nii.gz -o ${outputdir}/sub_cord_TEMP.nii.gz -sub ${cord}
     fslmaths ${outputdir}/sub_cord_TEMP.nii.gz -thr 0 -bin ${outputdir}/mask${o}.nii.gz
     fslstats ${outputdir}/mask${o}.nii.gz -m >> ${outputdir}/mask_averages.txt
     mask_avg=$( tail -1 ${outputdir}/mask_averages.txt )
@@ -242,15 +242,15 @@ if [[ ${include_CSF} -eq 1 ]]; then
 elif [[ include_CSF -eq 0 ]]; then
   echo "\n OK, no CSF. \n"
 fi
-exit 1
+# exit 1 #DELETE!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ###############################################################################
 # WM EROSION AND MASK CREATION:
 ###############################################################################
 # Create first mask using full cord mask:
 # Erode voxel layer from outer edges
-sct_maths -i ${input} -o ${outputdir}/erosion${o}.nii.gz -erode 1 -shape disk -dim 2
+sct_maths -i ${cord} -o ${outputdir}/erosion${o}.nii.gz -erode 1 -shape disk -dim 2
 # Subtract erosion from full mask to get only outer edge mask
-sct_maths -i ${input} -o ${outputdir}/mask_TEMP.nii.gz -sub ${outputdir}/erosion${o}.nii.gz
+sct_maths -i ${cord} -o ${outputdir}/mask_TEMP.nii.gz -sub ${outputdir}/erosion${o}.nii.gz
 # Subtract gm mask from mask to have no gm/wm overlap
 sct_maths -i ${outputdir}/mask_TEMP.nii.gz -o ${outputdir}/sub_gm_TEMP.nii.gz -sub ${gm}
 # Threshold out negative values (from previous step)
@@ -323,7 +323,7 @@ do
 done
 ###############################################################################
 # Calculate DVARS trace using PAM50_cord as the mask
-3dTto1D -input ${func} -mask ${input} -method dvars -prefix ${outputdir}/dvars.txt
+3dTto1D -input ${func} -mask ${cord} -method dvars -prefix ${outputdir}/dvars.txt
 ###############################################################################
 # Extract 8 largest tracts by volume, binarize then extract ts (WIP)
 # Binarize masks
@@ -352,10 +352,10 @@ if [[ ${smooth} -eq 1 ]]; then
   echo "\nSmoothing was requested. Beginning smoothing... \n"
   # Blur in cord mask (Find a way to automate this (maybe fslroi?)):
   echo "\nDelete top and bottom slice in mask (for smoothing).\nOverwrite file when saving (PAM50_cord_forSmoothing.nii.gz).\n"
-  cp ${input} template/PAM50_cord_forSmoothing.nii.gz
+  cp ${cord} template/PAM50_cord_forSmoothing.nii.gz
   blurMask=template/PAM50_cord_forSmoothing.nii.gz
   fsleyes ${blurMask}
-  # Loop through -k input to retrive x,y,z FWHM kernel values
+  # Loop through -k cord to retrive x,y,z FWHM kernel values
   # MAKE THIS SO THAT IT ONLY GOES THROUGH THIS LOOP IF THE INPUT IS LENGH STRLENGTH=5
   if [[ ${smooth} -eq 1 && ${STRLENGTH} -eq 5 ]]; then
     # If anisotropic:

--- a/x.heatmapPrep
+++ b/x.heatmapPrep
@@ -18,16 +18,19 @@ USAGE
   zsh x.heatmapPrep -i ~/data/sub-01/label -f ~/data/sub-01/func.nii.gz -o heatmap_output [-s] [-k x,y,z]
 
 MANDATORY ARGUMENTS
-  -i <input folder>       full path to label folder - contains the PAM50 template
-                          warped to the functional space (from sct_warp_template)
   -f <functional data>    full path to functional data file (same file used for SCT registration)
   -o <output folder>      desired name of output folder
+      **Either -i or -m is mandatory, but including both will only use -m**
 
 OPTIONAL ARGUMENTS
+  -i <input folder>       full path to label folder - contains the PAM50 template
+                          warped to the functional space (from sct_warp_template)
+  -m <mask>               full path to binary mask (spinal cord, etc.) to include
   -s                      smooth data with mask of spinal cord using AFNI 3dblurinmask [Default: no smoothing]
   -k <kernel>             define FWHM of isotropic or anisotropic smoothing kernel [Default: 2,2,6]
                           E.g. anisotropic: -k 2,2,6 ; isotropic -k 3
   -c {0,1}                include CSF masks (doesn't work with vertebral levels) [Default: ask user]
+
 
 EOF
 }
@@ -43,7 +46,7 @@ outputdir=
 smooth=0
 include_CSF=2
 fwhm=2,2,6 #####default value , make this compatible
-while getopts ':hi:f:o:sk:c:' OPTION; do
+while getopts ':hi:f:o:sk:c:m:' OPTION; do
   case $OPTION in
     h)
           usage
@@ -68,6 +71,9 @@ while getopts ':hi:f:o:sk:c:' OPTION; do
     c)
           include_CSF=${OPTARG}
           ;;
+    m)
+          sc_mask=${OPTARG}
+          ;;
     ?)
           echo "\e[91mUnknown flag!! -$OPTARG\e[0m"
           usage
@@ -76,8 +82,8 @@ while getopts ':hi:f:o:sk:c:' OPTION; do
   esac
 done
 # Check inputs exist
-if [[ -z ${data_path} ]]; then
-	 echo "ERROR: Input functional data path not specified. Exiting!\n"
+if [[ -z ${data_path} && -z ${sc_mask} ]]; then
+	 echo "ERROR: Label folder or mask path not specified. Exiting!\n"
      exit 1
 fi
 if [[ -z ${func} ]]; then
@@ -123,21 +129,22 @@ fi
 ################################################################################
 # End of checks, beginning analysis
 ################################################################################
-# Change directory to func folder and create output directory
-cd ${data_path}
-echo "\nLooking at functional data in... ${data_path} \n"
-mkdir ../${output_folder}
-echo '\nCreated new output directory called: ' ${output_folder} '\n'
-cd ../${output_folder}
+# # Change directory to func folder and create output directory - need to do this mask thing...
+# cd ${data_path}
+# echo "\nLooking at functional data in... ${data_path} \n"
+# mkdir ../${output_folder}
+# echo '\nCreated new output directory called: ' ${output_folder} '\n'
+# cd ../${output_folder}
+
+
+# p=abc/def/ghi/jkl.nii.gz # func
+func_dir=`dirname ${func}`
+echo "${func_dir}"
+mkdir ${func_dir}/${output_folder}
+cd ${func_dir}/${output_folder}
 outputdir=`pwd`
-cd ${data_path}
-# All inputs are data in functional space
-# Calculate functional mean image for visualizations later
-fslmaths ${func} -Tmean func_mean.nii.gz
-# The data_path should be the "label" folder containing these PAM50 files
-cord=template/PAM50_cord.nii.gz # cord mask
-levels=template/PAM50_levels.nii.gz # vertebral levels (NOT CORD)
-# Do checks then initialize mask descriptions log file
+
+# Do checks then
 if [[ -f "${outputdir}/maskDescriptions.txt" ]]; then
     echo -n "Looks like you've already done this analysis, continuing will cause files to be overwritten. Would you like to continue? \e[42mEnter y or n:\e[0m "
     read CONT
@@ -150,7 +157,38 @@ if [[ -f "${outputdir}/maskDescriptions.txt" ]]; then
       echo -e "\e[91mInput not recognized. Exiting!\e[0m\n"
     fi
 fi
+# Initialize mask descriptions log file
 date > ${outputdir}/maskDescriptions.txt
+# Check if mask input exists to do ANALYSIS IN MASK
+if [[ -n ${sc_mask} ]]; then
+   echo "Will output tissue timeseries within provided mask.\n"
+   # Add to mask descriptions log file
+   echo "Path to functional data input: ${func}" >> ${outputdir}/maskDescriptions.txt
+   echo "Path to output directory: ${outputdir}" >> ${outputdir}/maskDescriptions.txt
+   echo "" >> ${outputdir}/maskDescriptions.txt
+
+   # Re-Save input mask
+   m=00
+   cp ${sc_mask} ${outputdir}/mask${m}.nii.gz
+   echo "Input mask is mask${m}.nii.gz"
+   # Calculate timeseries for mask:
+   fslmeants -i ${func} -m ${sc_mask} --showall > ${outputdir}/mask${m}ts.txt
+   echo "INPUT MASK" >> ${outputdir}/maskDescriptions.txt
+   echo "mask${m}.nii.gz" >> ${outputdir}/maskDescriptions.txt
+   # Calculate DVARS trace using PAM50_cord as the mask
+   3dTto1D -input ${func} -mask ${sc_mask} -method dvars -prefix ${outputdir}/dvars.txt
+
+     exit 1
+fi
+
+cd ${data_path}
+# All inputs are data in functional space
+# Calculate functional mean image for visualizations later
+fslmaths ${func} -Tmean func_mean.nii.gz
+# The data_path should be the "label" folder containing these PAM50 files
+cord=template/PAM50_cord.nii.gz # cord mask
+levels=template/PAM50_levels.nii.gz # vertebral levels (NOT CORD)
+# Add to mask descriptions file
 echo "Path to analyzed data: ${data_path}" >> ${outputdir}/maskDescriptions.txt
 echo "Path to functional data input: ${func}" >> ${outputdir}/maskDescriptions.txt
 echo "Path to output directory: ${outputdir}" >> ${outputdir}/maskDescriptions.txt

--- a/x.heatmapPrep
+++ b/x.heatmapPrep
@@ -173,11 +173,13 @@ echo -n "Creating tissue type masks. GM/WM masks will be created. Do you want to
 read YN
 if [[ $YN =~ ^([yY])$ ]]; then
   echo "\n OK, will create CSF masks..."
-  echo -e "\e[1;35m    Edit CSF mask. Fill in full space inside CSF \e[0m"
+  echo -e "\e[1;35m    Edit CSF mask. Fill in top/bottom slices inside CSF \e[0m"
   echo -e "\e[1;35m    Save to same file name. Close window when done. \n \e[0m"
   cp ${outputdir}/full_csf_mask.nii.gz ${outputdir}/csfAndCord_mask.nii.gz
   csfCord=${outputdir}/csfAndCord_mask.nii.gz
   fsleyes ${outputdir}/csfAndCord_mask.nii.gz -cm red-yellow
+  fslmaths ${outputdir}/csfAndCord_mask.nii.gz -fillh ${outputdir}/csfAndCord_mask.nii.gz
+  fsleyes ${outputdir}/csfAndCord_mask.nii.gz -cm red-yellow &
   # After this, ${csfCord} is really csf+gm+wm
   # Erode and make masks (descriptions for each of these steps in WM section)
   # Use cord for subtraction (input)

--- a/x.heatmapPrep
+++ b/x.heatmapPrep
@@ -27,6 +27,7 @@ OPTIONAL ARGUMENTS
   -s                      smooth data with mask of spinal cord using AFNI 3dblurinmask [Default: no smoothing]
   -k <kernel>             define FWHM of isotropic or anisotropic smoothing kernel [Default: 2,2,6]
                           E.g. anisotropic: -k 2,2,6 ; isotropic -k 3
+  -c {0,1}                include CSF masks (doesn't work with vertebral levels) [Default: ask user]
 
 EOF
 }
@@ -40,8 +41,9 @@ scriptname=${0}
 data_path=
 outputdir=
 smooth=0
+include_CSF=2
 fwhm=2,2,6 #####default value , make this compatible
-while getopts ':hi:f:o:sk:' OPTION; do
+while getopts ':hi:f:o:sk:c:' OPTION; do
   case $OPTION in
     h)
           usage
@@ -62,6 +64,9 @@ while getopts ':hi:f:o:sk:' OPTION; do
           ;;
     k)
           fwhm=${OPTARG}
+          ;;
+    c)
+          include_CSF=${OPTARG}
           ;;
     ?)
           echo "\e[91mUnknown flag!! -$OPTARG\e[0m"
@@ -169,9 +174,20 @@ wm=${outputdir}/full_wm_mask.nii.gz
 o=0 #output
 i=0 #input
 m=0 #mask
-echo -n "Creating tissue type masks. GM/WM masks will be created. Do you want to include CSF? \e[42mEnter y or n:\e[0m "
-read YN
-if [[ $YN =~ ^([yY])$ ]]; then
+if [[ ${include_CSF} -eq 2 ]]; then
+    echo -n "Creating tissue type masks. GM/WM masks will be created. Do you want to include CSF? \e[42mEnter y or n:\e[0m "
+    read YN
+    if [[ $YN =~ ^([yY])$ ]]; then
+      include_CSF=1
+    elif [[ $YN =~ ^([nN])$ ]]; then
+      include_CSF=0
+      echo "\n OK, no CSF. \n"
+    else
+      echo -e "\e[91mInput not recognized. Exiting!\e[0m\n"
+      exit 1
+    fi
+fi
+if [[ ${include_CSF} -eq 1 ]]; then
   echo "\n OK, will create CSF masks..."
   echo -e "\e[1;35m    Edit CSF mask. Fill in top/bottom slices inside CSF \e[0m"
   echo -e "\e[1;35m    Save to same file name. Close window when done. \n \e[0m"
@@ -223,12 +239,10 @@ if [[ $YN =~ ^([yY])$ ]]; then
   fslmaths ${outputdir}/temp_csf_mask2.nii.gz -thr 0 -bin ${outputdir}/full_csf_mask.nii.gz
   rm ${outputdir}/temp_csf_mask1.nii.gz ${outputdir}/temp_csf_mask2.nii.gz
   csf=${outputdir}/full_csf_mask.nii.gz
-elif [[ $YN =~ ^([nN])$ ]]; then
+elif [[ include_CSF -eq 0 ]]; then
   echo "\n OK, no CSF. \n"
-else
-  echo -e "\e[91mInput not recognized. Exiting!\e[0m\n"
-  exit 1
 fi
+exit 1
 ###############################################################################
 # WM EROSION AND MASK CREATION:
 ###############################################################################


### PR DESCRIPTION
Created a flag for inclusion of CSF in heatmaps (closes #14). The user will be prompted if this flag is not used.

Fixed issue when including CSF when the number of masks is greater than 9 (closes #18)

The uses can now use -m to input a binary mask for x.heatmapPrep instead of it being required to input the -i label folder that requires registration of the spinal cord data to the PACM50 template. The mask can cover any region of the cord (or brainstem). In SCheatmap.m, if you used a mask with -m in x.heatmapPrep, you should use: useLevels=0, bySlice=1.
(closes #15)